### PR TITLE
Add option to publish VPC Flow Logs to either S3 or CW

### DIFF
--- a/modules/vpc-baseline/main.tf
+++ b/modules/vpc-baseline/main.tf
@@ -1,12 +1,28 @@
+locals {
+  is_cw_logs = var.vpc_log_destination_type == "cloud-watch-logs"
+}
+
 # --------------------------------------------------------------------------------------------------
-# Creates a log group for VPC Flow Logs
+# Enable VPC Flow Logs for the default VPC.
 # --------------------------------------------------------------------------------------------------
 
 resource "aws_cloudwatch_log_group" "default_vpc_flow_logs" {
-  count = var.enabled && var.enable_flow_logs ? 1 : 0
+  count = var.enabled && var.enable_flow_logs && local.is_cw_logs ? 1 : 0
 
   name              = var.vpc_log_group_name
   retention_in_days = var.vpc_log_retention_in_days
+
+  tags = var.tags
+}
+
+resource "aws_flow_log" "default_vpc_flow_logs" {
+  count = var.enabled && var.enable_flow_logs ? 1 : 0
+
+  log_destination_type = var.vpc_log_destination_type
+  log_destination      = local.is_cw_logs ? aws_cloudwatch_log_group.default_vpc_flow_logs[0].arn : var.vpc_flow_logs_s3_arn
+  iam_role_arn         = local.is_cw_logs ? var.vpc_flow_logs_iam_role_arn : null
+  vpc_id               = aws_default_vpc.default[0].id
+  traffic_type         = "ALL"
 
   tags = var.tags
 }
@@ -63,19 +79,3 @@ resource "aws_default_security_group" "default" {
     { Name = "Default Security Group" }
   )
 }
-
-# --------------------------------------------------------------------------------------------------
-# Enable VPC Flow Logs for the default VPC.
-# --------------------------------------------------------------------------------------------------
-
-resource "aws_flow_log" "default_vpc_flow_logs" {
-  count = var.enabled && var.enable_flow_logs ? 1 : 0
-
-  log_destination = aws_cloudwatch_log_group.default_vpc_flow_logs[0].arn
-  iam_role_arn    = var.vpc_flow_logs_iam_role_arn
-  vpc_id          = aws_default_vpc.default[0].id
-  traffic_type    = "ALL"
-
-  tags = var.tags
-}
-

--- a/modules/vpc-baseline/outputs.tf
+++ b/modules/vpc-baseline/outputs.tf
@@ -20,5 +20,5 @@ output "default_route_table" {
 
 output "vpc_flow_logs_group" {
   description = "The CloudWatch Logs log group which stores VPC Flow Logs."
-  value       = var.enabled ? aws_cloudwatch_log_group.default_vpc_flow_logs[0] : null
+  value       = var.enabled && local.is_cw_logs ? aws_cloudwatch_log_group.default_vpc_flow_logs[0] : null
 }

--- a/modules/vpc-baseline/variables.tf
+++ b/modules/vpc-baseline/variables.tf
@@ -8,6 +8,11 @@ variable "enable_flow_logs" {
   default     = true
 }
 
+variable "vpc_log_destination_type" {
+  description = "The type of the logging destination. Valid values: cloud-watch-logs, s3"
+  default     = "cloud-watch-logs"
+}
+
 variable "vpc_log_group_name" {
   description = "The name of CloudWatch Logs group to which VPC Flow Logs are delivered."
 }
@@ -17,7 +22,11 @@ variable "vpc_flow_logs_iam_role_arn" {
 }
 
 variable "vpc_log_retention_in_days" {
-  description = "Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely."
+  description = "Number of days to retain logs for. Only applies if vpc_log_destination_type is cloud-watch-logs. CIS recommends 365 days. Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely."
+}
+
+variable "vpc_flow_logs_s3_arn" {
+  description = "ARN of the S3 bucket where logs are sent. Only applies if vpc_log_destination_type is s3"
 }
 
 variable "tags" {

--- a/modules/vpc-baseline/variables.tf
+++ b/modules/vpc-baseline/variables.tf
@@ -13,20 +13,20 @@ variable "vpc_log_destination_type" {
   default     = "cloud-watch-logs"
 }
 
+variable "vpc_flow_logs_s3_arn" {
+  description = "ARN of the S3 bucket to which VPC Flow Logs are delivered if vpc_log_destination_type is s3."
+}
+
 variable "vpc_log_group_name" {
-  description = "The name of CloudWatch Logs group to which VPC Flow Logs are delivered."
+  description = "The name of CloudWatch Logs group to which VPC Flow Logs are delivered if vpc_log_destination_type is cloud-watch-logs."
 }
 
 variable "vpc_flow_logs_iam_role_arn" {
-  description = "The ARN of the IAM Role which will be used by VPC Flow Logs."
+  description = "The ARN of the IAM Role which will be used by VPC Flow Logs if vpc_log_destination_type is cloud-watch-logs."
 }
 
 variable "vpc_log_retention_in_days" {
-  description = "Number of days to retain logs for. Only applies if vpc_log_destination_type is cloud-watch-logs. CIS recommends 365 days. Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely."
-}
-
-variable "vpc_flow_logs_s3_arn" {
-  description = "ARN of the S3 bucket where logs are sent. Only applies if vpc_log_destination_type is s3"
+  description = "Number of days to retain logs if vpc_log_destination_type is cloud-watch-logs. CIS recommends 365 days. Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely."
 }
 
 variable "tags" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -140,13 +140,13 @@ output "support_iam_role" {
 
 output "vpc_flow_logs_iam_role" {
   description = "The IAM role used for delivering VPC Flow Logs to CloudWatch Logs."
-  value       = aws_iam_role.vpc_flow_logs_publisher
+  value       = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher : null
 }
 
 output "vpc_flow_logs_group" {
   description = "The CloudWatch Logs log group which stores VPC Flow Logs in each region."
 
-  value = {
+  value = local.is_cw_logs ? {
     "ap-northeast-1" = module.vpc_baseline_ap-northeast-1.vpc_flow_logs_group
     "ap-northeast-2" = module.vpc_baseline_ap-northeast-2.vpc_flow_logs_group
     "ap-south-1"     = module.vpc_baseline_ap-south-1.vpc_flow_logs_group
@@ -163,7 +163,7 @@ output "vpc_flow_logs_group" {
     "us-east-2"      = module.vpc_baseline_us-east-2.vpc_flow_logs_group
     "us-west-1"      = module.vpc_baseline_us-west-1.vpc_flow_logs_group
     "us-west-2"      = module.vpc_baseline_us-west-2.vpc_flow_logs_group
-  }
+  } : null
 }
 
 output "default_vpc" {

--- a/variables.tf
+++ b/variables.tf
@@ -205,13 +205,23 @@ variable "vpc_log_group_name" {
 }
 
 variable "vpc_log_retention_in_days" {
-  description = "Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely."
+  description = "Number of days to retain logs if vpc_log_destination_type is cloud-watch-logs. CIS recommends 365 days. Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely."
   default     = 365
 }
 
 variable "vpc_enable_flow_logs" {
   description = "The boolean flag whether to enable VPC Flow Logs in default VPCs"
   default     = true
+}
+
+variable "vpc_log_destination_type" {
+  description = "The type of the logging destination. Valid values: cloud-watch-logs, s3"
+  default     = "cloud-watch-logs"
+}
+
+variable "vpc_flow_logs_s3_arn" {
+  description = "ARN of the S3 bucket to which VPC Flow Logs are delivered if vpc_log_destination_type is s3."
+  default     = ""
 }
 
 # --------------------------------------------------------------------------------------------------

--- a/vpc_baselines.tf
+++ b/vpc_baselines.tf
@@ -65,7 +65,7 @@ module "vpc_baseline_ap-northeast-1" {
 
   enabled                    = contains(var.target_regions, "ap-northeast-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -83,7 +83,7 @@ module "vpc_baseline_ap-northeast-2" {
 
   enabled                    = contains(var.target_regions, "ap-northeast-2")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -101,7 +101,7 @@ module "vpc_baseline_ap-south-1" {
 
   enabled                    = contains(var.target_regions, "ap-south-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -119,7 +119,7 @@ module "vpc_baseline_ap-southeast-1" {
 
   enabled                    = contains(var.target_regions, "ap-southeast-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -137,7 +137,7 @@ module "vpc_baseline_ap-southeast-2" {
 
   enabled                    = contains(var.target_regions, "ap-southeast-2")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -155,7 +155,7 @@ module "vpc_baseline_ca-central-1" {
 
   enabled                    = contains(var.target_regions, "ca-central-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -173,7 +173,7 @@ module "vpc_baseline_eu-central-1" {
 
   enabled                    = contains(var.target_regions, "eu-central-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -191,7 +191,7 @@ module "vpc_baseline_eu-north-1" {
 
   enabled                    = contains(var.target_regions, "eu-north-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -209,7 +209,7 @@ module "vpc_baseline_eu-west-1" {
 
   enabled                    = contains(var.target_regions, "eu-west-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -227,7 +227,7 @@ module "vpc_baseline_eu-west-2" {
 
   enabled                    = contains(var.target_regions, "eu-west-2")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -245,7 +245,7 @@ module "vpc_baseline_eu-west-3" {
 
   enabled                    = contains(var.target_regions, "eu-west-3")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -263,7 +263,7 @@ module "vpc_baseline_sa-east-1" {
 
   enabled                    = contains(var.target_regions, "sa-east-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -281,7 +281,7 @@ module "vpc_baseline_us-east-1" {
 
   enabled                    = contains(var.target_regions, "us-east-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -299,7 +299,7 @@ module "vpc_baseline_us-east-2" {
 
   enabled                    = contains(var.target_regions, "us-east-2")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -317,7 +317,7 @@ module "vpc_baseline_us-west-1" {
 
   enabled                    = contains(var.target_regions, "us-west-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type
@@ -335,7 +335,7 @@ module "vpc_baseline_us-west-2" {
 
   enabled                    = contains(var.target_regions, "us-west-2")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
+  vpc_flow_logs_iam_role_arn = local.is_cw_logs ? aws_iam_role.vpc_flow_logs_publisher[0].arn : null
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
   vpc_log_destination_type   = var.vpc_log_destination_type

--- a/vpc_baselines.tf
+++ b/vpc_baselines.tf
@@ -1,8 +1,14 @@
+locals {
+  is_cw_logs = var.vpc_log_destination_type == "cloud-watch-logs"
+}
+
 # --------------------------------------------------------------------------------------------------
 # Create an IAM Role for publishing VPC Flow Logs into CloudWatch Logs group.
 # Reference: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html#flow-logs-iam
 # --------------------------------------------------------------------------------------------------
 data "aws_iam_policy_document" "vpc_flow_logs_publisher_assume_role_policy" {
+  count = var.vpc_enable_flow_logs && local.is_cw_logs ? 1 : 0
+
   statement {
     principals {
       type        = "Service"
@@ -13,13 +19,17 @@ data "aws_iam_policy_document" "vpc_flow_logs_publisher_assume_role_policy" {
 }
 
 resource "aws_iam_role" "vpc_flow_logs_publisher" {
+  count = var.vpc_enable_flow_logs && local.is_cw_logs ? 1 : 0
+
   name               = var.vpc_iam_role_name
-  assume_role_policy = data.aws_iam_policy_document.vpc_flow_logs_publisher_assume_role_policy.json
+  assume_role_policy = data.aws_iam_policy_document.vpc_flow_logs_publisher_assume_role_policy[0].json
 
   tags = var.tags
 }
 
 data "aws_iam_policy_document" "vpc_flow_logs_publish_policy" {
+  count = var.vpc_enable_flow_logs && local.is_cw_logs ? 1 : 0
+
   statement {
     actions = [
       "logs:CreateLogGroup",
@@ -33,10 +43,12 @@ data "aws_iam_policy_document" "vpc_flow_logs_publish_policy" {
 }
 
 resource "aws_iam_role_policy" "vpc_flow_logs_publish_policy" {
-  name = var.vpc_iam_role_policy_name
-  role = aws_iam_role.vpc_flow_logs_publisher.id
+  count = var.vpc_enable_flow_logs && local.is_cw_logs ? 1 : 0
 
-  policy = data.aws_iam_policy_document.vpc_flow_logs_publish_policy.json
+  name = var.vpc_iam_role_policy_name
+  role = aws_iam_role.vpc_flow_logs_publisher[0].id
+
+  policy = data.aws_iam_policy_document.vpc_flow_logs_publish_policy[0].json
 }
 
 # --------------------------------------------------------------------------------------------------
@@ -53,9 +65,11 @@ module "vpc_baseline_ap-northeast-1" {
 
   enabled                    = contains(var.target_regions, "ap-northeast-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -69,9 +83,11 @@ module "vpc_baseline_ap-northeast-2" {
 
   enabled                    = contains(var.target_regions, "ap-northeast-2")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -85,9 +101,11 @@ module "vpc_baseline_ap-south-1" {
 
   enabled                    = contains(var.target_regions, "ap-south-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -101,9 +119,11 @@ module "vpc_baseline_ap-southeast-1" {
 
   enabled                    = contains(var.target_regions, "ap-southeast-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -117,9 +137,11 @@ module "vpc_baseline_ap-southeast-2" {
 
   enabled                    = contains(var.target_regions, "ap-southeast-2")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -133,9 +155,11 @@ module "vpc_baseline_ca-central-1" {
 
   enabled                    = contains(var.target_regions, "ca-central-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -149,9 +173,11 @@ module "vpc_baseline_eu-central-1" {
 
   enabled                    = contains(var.target_regions, "eu-central-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -165,9 +191,11 @@ module "vpc_baseline_eu-north-1" {
 
   enabled                    = contains(var.target_regions, "eu-north-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -181,9 +209,11 @@ module "vpc_baseline_eu-west-1" {
 
   enabled                    = contains(var.target_regions, "eu-west-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -197,9 +227,11 @@ module "vpc_baseline_eu-west-2" {
 
   enabled                    = contains(var.target_regions, "eu-west-2")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -213,9 +245,11 @@ module "vpc_baseline_eu-west-3" {
 
   enabled                    = contains(var.target_regions, "eu-west-3")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -229,9 +263,11 @@ module "vpc_baseline_sa-east-1" {
 
   enabled                    = contains(var.target_regions, "sa-east-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -245,9 +281,11 @@ module "vpc_baseline_us-east-1" {
 
   enabled                    = contains(var.target_regions, "us-east-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -261,9 +299,11 @@ module "vpc_baseline_us-east-2" {
 
   enabled                    = contains(var.target_regions, "us-east-2")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -277,9 +317,11 @@ module "vpc_baseline_us-west-1" {
 
   enabled                    = contains(var.target_regions, "us-west-1")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
@@ -293,10 +335,11 @@ module "vpc_baseline_us-west-2" {
 
   enabled                    = contains(var.target_regions, "us-west-2")
   vpc_log_group_name         = var.vpc_log_group_name
-  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher.arn
+  vpc_flow_logs_iam_role_arn = aws_iam_role.vpc_flow_logs_publisher[0].arn
   vpc_log_retention_in_days  = var.vpc_log_retention_in_days
   enable_flow_logs           = var.vpc_enable_flow_logs
+  vpc_log_destination_type   = var.vpc_log_destination_type
+  vpc_flow_logs_s3_arn       = var.vpc_flow_logs_s3_arn
 
   tags = var.tags
 }
-


### PR DESCRIPTION
Address https://github.com/nozaq/terraform-aws-secure-baseline/issues/144

- `vpc_log_destination_type` defaults to CW to avoid breaking existing deployments
- if S3 is used, bucket creation is outside the scope of this module
- also addresses issue where IAM Role was created even if VPC flow logs were not enabled
